### PR TITLE
gives overrides options higher priority to the payload

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -55,7 +55,7 @@ class ApiBase {
       headers: {
         'Accept': 'application/json'
       }
-    }, this.config.overrides, payload)
+    }, payload, this.config.overrides)
 
     try {
       const ep = this.config.query ? `${endpoint}?${this.config.query}` : `${endpoint}`


### PR DESCRIPTION
Hello,
I am trying to use sapper-httpclient in a project of mine, but I need to set an Authorization header.

The `override()` method looks like a nice place to do this, and it works fine for all the GET calls:

``` javascript
create()
 .endpoint('https://myserver.com/')
 .override({
      headers: {
        'Authorization': 'Basic ' + Buffer.from(user.username + ":" + user.password).toString('base64'),
      },
    })
 .get()
```

But when I set a `payload()` in a POST or PUT calls, it overrides all the headers with a `'Content-Type': 'application/json'` and I have no way to change this.

In order to fix this, I tried switching the payload and overrides during the merge into the request options object.


