### PR TITLE
add status codes to HttpError

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -114,7 +114,7 @@ class ApiBase {
       }
 
       const ClientError = byCode(r.status)
-      throw new ClientError(r.statusText, content)
+      throw new ClientError(r.statusText, r.status, content)
     } catch (e) {
       if (attempt < retry.attempts && retry.errors.includes(e.code)) {
         console.warn(`Got ${e.code} when calling ${endpoint}. Retrying request (${attempt}/${retry.attempts})`)

--- a/lib/api/api.spec.js
+++ b/lib/api/api.spec.js
@@ -105,13 +105,15 @@ describe('util/api', () => {
 
       it('with unknown status code', async () => {
         let error
+        let statusCode
         const expectedError = 'hit default handler'
+        let expectedStatusCode = Math.floor(Math.random() * 300) + 300
 
         clientStub.resolves({
           ok: false,
           statusText: 'No',
           json: stub().resolves({ error: 'no' }),
-          status: 419,
+          status: expectedStatusCode,
           headers: new Map()
         })
 
@@ -120,10 +122,12 @@ describe('util/api', () => {
           .endpoint('some/url')
           .default(e => {
             error = expectedError
+            statusCode = e.status
           })
           .get()
 
         expect(error).to.equal(expectedError)
+        expect(statusCode).to.equal(expectedStatusCode)
       })
 
       it('passes status code as second parameter', async () => {
@@ -196,6 +200,7 @@ describe('util/api', () => {
 
       it('with known status code', async () => {
         let error
+        let statusCode
         const expectedErrorMessage = 'no'
 
         clientStub.resolves({
@@ -212,10 +217,12 @@ describe('util/api', () => {
           .endpoint('some/url')
           .accessDenied(e => {
             error = e.message
+            statusCode = e.status
           })
           .get()
 
         expect(error).to.equal(expectedErrorMessage)
+        expect(statusCode).to.equal(401)
       })
     })
 

--- a/lib/errors/errors.js
+++ b/lib/errors/errors.js
@@ -1,9 +1,10 @@
 'use strict'
 
 class HttpError extends Error {
-  constructor (message, body) {
+  constructor (message, status, body) {
     super(message)
     this.body = body
+    this.status = status
   }
 }
 


### PR DESCRIPTION
This change will make handling errors that are not in the error mappings more cleaner.

Currently, if an application reports error codes that are not in the error mapping: (ex: 401 Unauthorized, 400 Bad Request, etc)
You have to do some if statements with the **message string** on the ` .default()` error handling and figure out the status code if you need that- which isn't the best.

This gives the user to handle the error with the status code itself.