### PR TITLE
fix: non-`204` empty responses are parsed for JSON

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -103,14 +103,14 @@ class Api extends Behaviours {
   }
 
   _hasContent (response) {
-    const contentLength = response.headers.get('content-length')
+    const contentLength = parseInt(response.headers.get('content-length'), 10)
 
     const isNoContentResponse = response.status === 204
     if (isNoContentResponse) {
       return false
     }
 
-    const headerExists = Number.isInteger(contentLength)
+    const headerExists = !isNaN(contentLength)
     return !headerExists || contentLength > 0
   }
 

--- a/lib/api/index.spec.mjs
+++ b/lib/api/index.spec.mjs
@@ -327,7 +327,7 @@ describe('util/api', () => {
         const jsonFunction = stub()
 
         const headers = new Map()
-        headers.set('content-length', 0)
+        headers.set('content-length', '0')
 
         clientStub.resolves({
           json: jsonFunction,


### PR DESCRIPTION
...resulting in error. `Headers` interface maps to string values — parse to number before validating length.